### PR TITLE
WIP: Add basic CLI parsing

### DIFF
--- a/bin/analyze.py
+++ b/bin/analyze.py
@@ -1,10 +1,87 @@
+#! /usr/bin/env python3
+"""
+CLI for the auto-analyzer for the Python track on Exercism.io.
+"""
+import argparse
+import importlib.util
 import sys
-import os
+from pathlib import Path
+from typing import NamedTuple
 
-file_path = os.path.join(sys.argv[2], ' {}.py'.format(sys.argv[1]))
+ROOT = Path(__file__).resolve(strict=True)
+LIBRARY = ROOT.parent.parent.joinpath("lib").resolve(strict=True)
+ANALYZERS = {f.parent.name: f for f in LIBRARY.glob("*/analyzer.py")}
 
-# Add path to import analyzer
-sys.path.append('../lib/{}'.format(sys.argv[1]))
 
-import analyzer
-analyzer.analyze(file_path)
+class Exercise(NamedTuple):
+    """
+    An individual Exercise to anaylze.
+    """
+
+    name: str
+    path: Path
+    tests_path: Path
+
+    def analyze(self):
+        """
+        Perform automatic analysis on this Exercise.
+        """
+        module_name = f"{self.path.name}_analyzer"
+        module = ANALYZERS[self.name]
+        spec = importlib.util.spec_from_file_location(module_name, module)
+        analyzer = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(analyzer)
+        sys.modules[module_name] = analyzer
+        return analyzer.analyze(str(self.path))
+
+    @staticmethod
+    def sanitize_name(name: str) -> str:
+        """
+        Sanitize an Exercise name (ie "two-fer" -> "two_fer").
+        """
+        return name.replace("-", "_")
+
+    @classmethod
+    def factory(cls, name: str, directory: Path) -> "Exercise":
+        """
+        Build an Exercise from its name and the directory where its files exist.
+        """
+        sanitized = cls.sanitize_name(name)
+        path = directory.joinpath(f"{sanitized}.py").resolve()
+        tests_path = directory.joinpath(f"{sanitized}_test.py").resolve()
+        return cls(name, path, tests_path)
+
+
+def main():
+    """
+    Parse CLI arguments and perform the analysis.
+    """
+    def directory(path: str) -> Path:
+        selection = Path(path)
+        if not selection.is_dir():
+            raise argparse.ArgumentTypeError(f"{selection} must be a directory")
+        return selection
+
+    parser = argparse.ArgumentParser(
+        description="Perform automatic code analysis of a Python track exercise."
+    )
+    parser.add_argument(
+        "exercise",
+        metavar="EXERCISE",
+        type=str,
+        choices=ANALYZERS.keys(),
+        help="name of the exercise to analyze (One of: %(choices)s)",
+    )
+    parser.add_argument(
+        "directory",
+        metavar="DIR",
+        type=directory,
+        help="directory where the the [EXERCISE].py file located",
+    )
+    args = parser.parse_args()
+    exercise = Exercise.factory(args.exercise, args.directory)
+    exercise.analyze()
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/two-fer/analyzer.py
+++ b/lib/two-fer/analyzer.py
@@ -29,33 +29,31 @@ def analyze(file_path):
     try:
         with open(file_path, 'r') as f:
            user_solution = f.read()
-    except:
+    except Exception:
         # If the proper file cannot be found, disapprove this solution
         output = {}
         output['status'] = 'disapprove_with_comment'
         output['comment'] = [no_module]
         output['pylint_comment'] = []
-        json_output = json.dumps(output)
+        json_output = json.dumps(output, indent=4)
         analysis_out = os.path.dirname(file_path) + '/analysis.json'
-        file = open(analysis_out, 'w')
-        file.write(json_output)
-        file.close()
+        with open(analysis_out, 'w') as f:
+            f.write(json_output)
         return ([no_module], False, [], 'disapprove_with_comment')
 
     try:
         # Parse file to abstract syntax tree
         tree = ast.parse(user_solution)
-    except:
+    except Exception:
         # If ast.parse fails, the code is malformed and this solution is disapproved
         output = {}
         output['status'] = 'disapprove_with_comment'
         output['comment'] = [malformed_code]
         output['pylint_comment'] = []
-        json_output = json.dumps(output)
+        json_output = json.dumps(output, indent=4)
         analysis_out = os.path.dirname(file_path) + '/analysis.json'
-        file = open(analysis_out, 'w')
-        file.write(json_output)
-        file.close()
+        with open(analysis_out, 'w') as f:
+            f.write(json_output)
         return ([malformed_code], False, [], 'disapprove_with_comment')
 
     # List of comments to return at end, each comment is a string
@@ -92,7 +90,7 @@ def analyze(file_path):
                 # Search for use of incorrect default argument
                 try:
                     if node.defaults[0].s != 'you' and wrong_def_arg not in comments: comments += [wrong_def_arg]
-                except:
+                except Exception:
                     if wrong_def_arg not in comments: comments += [wrong_def_arg]
 
         # Search for use of unnecessary conditionals
@@ -108,13 +106,13 @@ def analyze(file_path):
         elif isinstance(node, ast.Call):
             try:
                 if node.func.attr == 'format': uses_format = True
-            except:
+            except Exception:
                 pass
 
         # Search for use of f-strings
         try:
             if isinstance(node, ast.FormattedValue): uses_f_string = True
-        except:
+        except Exception:
             pass # Fail if python version is too low
           
     if not has_method:
@@ -142,10 +140,9 @@ def analyze(file_path):
     output['status'] = status
     output['comment'] = comments
     output['pylint_comment'] = pylint_comments
-    json_output = json.dumps(output)
+    json_output = json.dumps(output, indent=4)
     analysis_out = os.path.dirname(file_path) + '/analysis.json'
-    file = open(analysis_out,  'w')
-    file.write(json_output)
-    file.close()
+    with open(analysis_out,  'w') as f:
+        f.write(json_output)
 
     return (comments, approve, pylint_comments, status)


### PR DESCRIPTION
After seeing some discussion on Slack I thought I'd take whack at improving the CLI interface of the Python auto-analysis tool a little.

Converts `bin/analyze.py` to use **argparse**, adding some help and basic
argument parsing and validation. Will now limit the first argument to a valid EXERCISE name (ie `two-fer`) for which a corresponding `lib/EXERCISE/analyzer.py` file exists. The second argument must also be a directory that actually exists on disk.

Updates dynamic import of the analyzer.py to **not** use **sys.path** maniupulation, which was never really a "best" practice and has become more than a little problematic in Python 3.

Also updates `lib/two-fer/analyzer.py` with more rationalized exception handling, uses the **with** context manager on output, and makes the resulting JSON a little more human readable.

Not sure how widely this thing is being used yet so I've made this a WIP so I can open this up for discussion. For that reason I _have not_ updated the README to reflect the changes described above.