### PR TITLE
Fix for Issue 18: Output Arguments not used

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @exercism/maintainers-admin
+* @cmccandless
+* @bethanyg
+.github/CODEOWNERS  @exercism/maintainers-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @exercism/python-representer
+* @cmccandless @BethanyG
 .github/CODEOWNERS  @exercism/maintainers-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,2 @@
-* @cmccandless
-* @bethanyg
+* @cmccandless @BethanyG 
 .github/CODEOWNERS  @exercism/maintainers-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @cmccandless @BethanyG 
+* @exercism/python-representer
 .github/CODEOWNERS  @exercism/maintainers-admin

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -3,4 +3,4 @@
 # Usage:
 # ./bin/run.sh two_fer ~/test/
 export PYTHONPATH=/opt/analyzer/lib/$1/
-python bin/run.py $1 $2
+python bin/run.py $1 $2 $3

--- a/lib/common/analysis.py
+++ b/lib/common/analysis.py
@@ -106,11 +106,11 @@ class Analysis(dict):
             Status.REFER_TO_MENTOR, comment, pylint_comment or [], approvable=approvable
         )
 
-    def dump(self, path: Path):
+    def dump(self, out_path: Path):
         """
         Dump's the current state to analysis.json.
         As a convenience returns the Anaylsis itself.
         """
-        with open(path, "w") as dst:
+        with open(out_path, "w") as dst:
             json.dump(self, dst, indent=4, cls=AnalysisEncoder)
         return self

--- a/lib/common/exercise.py
+++ b/lib/common/exercise.py
@@ -25,7 +25,8 @@ class Exercise(NamedTuple):
     """
 
     name: str
-    path: Path
+    in_path: Path
+    out_path: Path
     tests_path: Path
 
     @property
@@ -53,7 +54,7 @@ class Exercise(NamedTuple):
         """
         Perform automatic analysis on this Exercise.
         """
-        return self.analyzer.analyze(self.path)
+        return self.analyzer.analyze(self.in_path, self.out_path)
 
     @staticmethod
     def sanitize_name(name: str) -> str:
@@ -70,7 +71,7 @@ class Exercise(NamedTuple):
         return ANALYZERS
 
     @classmethod
-    def factory(cls, name: str, directory: Path) -> "Exercise":
+    def factory(cls, name: str, in_directory: Path, out_directory: Path) -> "Exercise":
         """
         Build an Exercise from its name and the directory where its files exist.
         """
@@ -78,6 +79,7 @@ class Exercise(NamedTuple):
             path = LIBRARY.joinpath(name, "analyzer.py")
             raise ExerciseError(f"No analyzer discovered at {path}")
         sanitized = cls.sanitize_name(name)
-        path = directory.joinpath(f"{sanitized}.py").resolve()
-        tests_path = directory.joinpath(f"{sanitized}_test.py").resolve()
-        return cls(name, path, tests_path)
+        in_path = in_directory.joinpath(f"{sanitized}.py").resolve()
+        out_path = out_directory.joinpath(f"{sanitized}.py").resolve()
+        tests_path = in_directory.joinpath(f"{sanitized}_test.py").resolve()
+        return cls(name, in_path, out_path, tests_path)

--- a/lib/two-fer/analyzer.py
+++ b/lib/two-fer/analyzer.py
@@ -20,7 +20,7 @@ class Comments(BaseComments):
     PERCENT_FORMATTING = ("two-fer", "percent_formatting")
 
 
-def analyze(path: Path):
+def analyze(in_path: Path, out_path: Path):
     """
     Analyze the user's Two Fer solution to give feedback and disapprove malformed solutions. Outputs a JSON that
     conforms to Exercism's Auto-Mentor project interface.
@@ -30,11 +30,11 @@ def analyze(path: Path):
         and a 'status' string corresponding to the value of the status key in the generated JSON, as its fourth
         entry.
     """
-    output_file = path.parent.joinpath("analysis.json")
+    output_file = out_path.parent.joinpath("analysis.json")
 
     # Input file
     try:
-        user_solution = path.read_text()
+        user_solution = in_path.read_text()
     except OSError as err:
         # If the proper file cannot be found, disapprove this solution
         return Analysis.disapprove([Comments.NO_MODULE]).dump(output_file)
@@ -130,7 +130,7 @@ def analyze(path: Path):
         approvable = False
 
     # Use Pylint to generate comments for code, e.g. if code follows PEP8 Style Convention
-    pylint_stdout, _ = lint.py_run(str(path), return_std=True)
+    pylint_stdout, _ = lint.py_run(str(in_path), return_std=True)
     pylint_comments = [pylint_stdout.getvalue()]
 
     # Handle a known optimal solution


### PR DESCRIPTION
**Note:**  This is only fixed/tested for the `two-fer` exercise, since it is the only exercise which has an `analyzer.py` file written (yet).  It will have to be re-tested once we get analyzers written for a new concept exercise or two. 

*  Added the third argument (_output_directory_) to the `run.sh` script.
*  Added the `out_path` (_output_directory_) to the `dump()` function in `analysis.py`
*  Modified `exercise.py` to add `in_path` (_input_directory_) and `out_path` (_output_directory_) to the class variables, class factory, and analyze method.
* Modified the analyze method of two-fers `analyzer.py` to take both `in_path` (_input_directory_) and `out_path` (_output_directory_) as parameters.  Changed the `output_file` variable to the `out_path` (_output_directory_).