### PR TITLE
Added PyLint as a Base Checker and Updated Comments and Rules

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 """
-CLI for the auto-analyzer for the Python track on Exercism.io.
+CLI for the auto-analyzer for the Python track on Exercism.org.
 ./bin/run.sh two_fer ~/solution-238382y7sds7fsadfasj23j/ ~/solution-238382y7sds7fsadfasj23j/output/
 """
 import argparse

--- a/comments/general/malformed_code.md
+++ b/comments/general/malformed_code.md
@@ -1,1 +1,4 @@
-The code is malformed and cannot be parsed for analysis.
+# general malformed code
+
+Something went wrong.
+The code appears to be malformed and cannot be parsed for analysis.

--- a/comments/general/no_return.md
+++ b/comments/general/no_return.md
@@ -1,2 +1,7 @@
-'return' is not used to return the result string. This solution should fail pytest.
-Try ```run pytest``` inside the two-fer directory and observe the pass/fail results.
+# general missing return statement
+
+A `return` statement is not being used in this function to return results.
+ This code should have failed one or more test cases during testing.
+
+Please review the test results, and edit the code accordingly.
+

--- a/comments/pylint/convention.md
+++ b/comments/pylint/convention.md
@@ -1,0 +1,10 @@
+# pylint convention
+
+**Line %{lineno}** [ _%{code}_ ]  :  %{message}.
+ Was reported.
+
+Which means this code doesn't follow general [`code style`][PEP8] conventions.
+While this type of issue generally doesn't affect the way code _executes_, it can hurt
+readability or the performance of automated tools such as documentation generators or test runners.
+
+[PEP8]: https://www.python.org/dev/peps/pep-0008/

--- a/comments/pylint/error.md
+++ b/comments/pylint/error.md
@@ -1,0 +1,6 @@
+# pylint informational
+
+**Line %{lineno}** [ _%{code}_ ]  :  %{message}.
+ Was reported.
+
+This code has an error or problem that should be addressed.

--- a/comments/pylint/fatal.md
+++ b/comments/pylint/fatal.md
@@ -1,0 +1,7 @@
+# pylint fatal
+
+**Line %{lineno}** [ _%{code}_ ]  :  %{message}.
+ Was reported.
+
+This is a fatal error. Something went wrong, and the code cannot be processed any further.
+

--- a/comments/pylint/informatonal.md
+++ b/comments/pylint/informatonal.md
@@ -1,0 +1,9 @@
+# pylint informational
+
+
+**Line %{lineno}** [ _%{code}_ ]  :  %{message}.
+ Was reported.
+
+There is `FIXME`/`TODO`/`XXX` style comment or other "informational" pattern or note in the code.
+ These tags are often used to annotate places where code is stubbed out but needs work - or to highlight potential design flaws or bugs that need to be addressed in the future.
+

--- a/comments/pylint/refactor.md
+++ b/comments/pylint/refactor.md
@@ -4,7 +4,7 @@
  Was reported.
 
 This code is emitting a [`code smell`][code smell], and may be in need of
-a re-write or refactor.
+a rewrite or refactor.
  This doesn't mean the code is incorrect or buggy in a _technical sense_ -- only that it
 appears to have one or more patterns that could lead to _future_ bugs or maintenance issues.
 Consider taking a closer look at it.

--- a/comments/pylint/refactor.md
+++ b/comments/pylint/refactor.md
@@ -1,0 +1,12 @@
+# pylint refactor
+
+**Line %{lineno}** [ _%{code}_ ]  :  %{message}.
+ Was reported.
+
+This code is emitting a [`code smell`][code smell], and may be in need of
+a re-write or refactor.
+ This doesn't mean the code is incorrect or buggy in a _technical sense_ -- only that it
+appears to have one or more patterns that could lead to _future_ bugs or maintenance issues.
+Consider taking a closer look at it.
+
+[code smell]: https://en.wikipedia.org/wiki/Code_smell

--- a/comments/pylint/warning.md
+++ b/comments/pylint/warning.md
@@ -1,0 +1,9 @@
+# pylint warning
+
+**Line %{lineno}** [ _%{code}_ ]  :  %{message}.
+ Was reported.
+
+There is an issue in the code that could lead to a bug or error in the program.
+While this error might not be _severe_, it could lead to more severe issues in the future.
+It is recommend the problem be addressed before proceeding further.
+

--- a/comments/two-fer/conditionals.md
+++ b/comments/two-fer/conditionals.md
@@ -1,2 +1,15 @@
-Conditionals are unnecessarily used in this solution. An ideal solution should
-make use of a default argument and either f-strings or str.format.
+# unnecessary conditionals
+
+[Conditionals][conditionals] are unnecessarily used in this solution.
+Making use of a [`default argument`][default argument] in combination with either [`str.format`][str.format] or [`f-strings`][f-strings] (_otherwise known as `formatted string literals` or `interpolated strings`_) can make the code clearer and less verbose.
+
+See this post on [python default arguments][python default arguments] for additional details.
+The blog post [string formatting in python][string formatting in python] can also be a good starting point for learning about Python's string formatting options.
+
+[conditionals]: https://github.com/exercism/python/blob/main/concepts/conditionals/introduction.md
+[str.format]: https://docs.python.org/3/library/stdtypes.html#str.format)
+[f-strings]: https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals
+[default argument]: https://docs.python.org/3/tutorial/controlflow.html#default-argument-values
+[python default arguments]: https://blog.finxter.com/python-default-arguments/
+[string formatting in python]: https://realpython.com/python-string-formatting/
+

--- a/comments/two-fer/no_def_arg.md
+++ b/comments/two-fer/no_def_arg.md
@@ -1,2 +1,15 @@
-No default arguments are used in this solution. An ideal solution should make use of a default argument
-and either f-strings or str.format.
+# no default arguments used
+
+No [`default argument`][default argument] is used in the function definition of this this solution.
+[Default arguments in Python][default arguments in python] can help guard against situations where a function is called without an expected argument or no argument is available to pass.
+`Default arguments` can also help avoid unnecessary conditional code or checks inside a function.
+
+This solution can be improved by making use of a `default argument` in combination with either [`str.format`][str.format] or [`f-strings`][f-strings] (_AKA: `formatted string literals` or `interpolated strings`_).
+
+[String Formatting in Python][string formatting in python] from Real Python can be a good starting point for learning about Python's string formatting options.
+
+[default argument]: https://en.wikipedia.org/wiki/Default_argument
+[default arguments in python]: https://blog.finxter.com/python-default-arguments/
+[str.format]: https://docs.python.org/3/library/stdtypes.html#str.format
+[f-strings]: https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals
+[string formatting in python]: https://realpython.com/python-string-formatting/

--- a/comments/two-fer/no_method.md
+++ b/comments/two-fer/no_method.md
@@ -1,1 +1,5 @@
-No method called two_fer.
+# no method or function definition found
+
+We were unable to find a function or method called `two_fer`.
+This means the expected function is either missing or mis-named, and no further analysis can be done.
+To continue with analysis, please either create or rename the function or method to `two_fer`.

--- a/comments/two-fer/no_module.md
+++ b/comments/two-fer/no_module.md
@@ -1,1 +1,4 @@
-No module called two_fer.py found in file path.
+# missing module or misnamed file
+
+We were unable to find a file called `two_fer.py` in the file path.
+Without the file, an analysis of the solution cannot be performed.

--- a/comments/two-fer/percent_formatting.md
+++ b/comments/two-fer/percent_formatting.md
@@ -1,2 +1,14 @@
-%-formatting is a valid approach, but f-strings and str.format offer more
-functionality and elegant solutions.
+# percent or "old style" formatting
+
+This solution uses `%-formatting` or [`old-style formatting`][old-style formatting] for strings.
+
+While `%-formatting` is an entirely valid approach, it can create representation or readability issues.
+Using the method [`str.format()`][str.format()] or [`f-strings`][f-strings] (_AKA `formatted string literals` or `interpolated strings`_) can offer options that improve readability and make variable replacement within strings clearer.
+
+The blog post [String Formatting in Python][string formatting in python] is a good starting point for understanding all of Python's string formatting options, and [Newer Python String Format Techniques][newer python string format techniques] also provides some good tips and tricks for using `str.format()` and `f-strings`.
+
+[f-strings]: https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals
+[newer python string format techniques]: https://realpython.com/python-formatted-output/
+[old-style formatting]: https://docs.python.org/release/3.9.6/library/stdtypes.html#old-string-formatting
+[str.format()]: https://docs.python.org/3/library/stdtypes.html#str.format
+[string formatting in python]: https://realpython.com/python-string-formatting/

--- a/comments/two-fer/simple_concat.md
+++ b/comments/two-fer/simple_concat.md
@@ -1,2 +1,9 @@
-String concatenation with the + operator is a valid approach, but f-strings
-and str.format offer more functionality and elegant solutions.
+String concatenation with the + operator is a valid approach, but it can create maintenance and readability issues.
+Using the method [`str.format()`][str.format()] or [`f-strings`][f-strings] (_AKA `formatted string literals` or `interpolated strings`_) can offer options that improve maintainability and make variable replacement within strings clearer.
+
+The blog post [String Formatting in Python][string formatting in python] is a good starting point for understanding all of Python's string formatting options, and [Newer Python String Format Techniques][newer python string format techniques] also provides some good tips and tricks for using `str.format()` and `f-strings`.
+
+[f-strings]: https://docs.python.org/3/reference/lexical_analysis.html#formatted-string-literals
+[newer python string format techniques]: https://realpython.com/python-formatted-output/
+[str.format()]: https://docs.python.org/3/library/stdtypes.html#str.format
+[string formatting in python]: https://realpython.com/python-string-formatting/

--- a/comments/two-fer/wrong_def_arg.md
+++ b/comments/two-fer/wrong_def_arg.md
@@ -1,1 +1,1 @@
-A value other than 'you' is used as a default argument.
+A value other than 'you' is bing used as a default argument.

--- a/lib/common/analysis.py
+++ b/lib/common/analysis.py
@@ -51,7 +51,7 @@ class Analysis(dict):
     @classmethod
     def celebrate(cls,  comments=None):
         """
-        Create an Anaylsis that is approved.
+        Create an Analysis that is approved.
         If non-optimal, comment should be a list of Comments.
         """
         return cls(Summary.CELEBRATE, comments or [])
@@ -96,7 +96,7 @@ class Analysis(dict):
     def dump(self, out_path: Path):
         """
         Dump's the current state to analysis.json.
-        As a convenience returns the Anaylsis itself.
+        As a convenience returns the Analysis itself.
         """
         with open(out_path, "w") as dst:
             json.dump(self, dst, indent=4, cls=AnalysisEncoder)

--- a/lib/common/exercise.py
+++ b/lib/common/exercise.py
@@ -68,7 +68,7 @@ class Exercise(NamedTuple):
     @classmethod
     def available_analyzers(cls):
         """
-        Returns the map of avaiable EXERCISE/analyzer.py files.
+        Returns the map of available EXERCISE/analyzer.py files.
         """
         return ANALYZERS
 

--- a/lib/common/pylint_comments.py
+++ b/lib/common/pylint_comments.py
@@ -32,9 +32,19 @@ def generate_pylint_comments(in_path):
 
     for line in cleaned_pylint_output:
         if line[0]:
-            pylint_comments.append(Comment(type=status_mapping[line[0]],
-                                           params={'lineno': line[1], 'code': line[2], 'message': line[3]},
-                                           comment=f'python.pylint.{line[0]}'))
+            if line[2] == "C0301 line-too-long":
+                continue
+
+            if line[2] in ("C0114 missing-module-docstring",
+                           "C0116 missing-function-docstring",
+                           "C0304 missing-final-newline"):
+
+                pylint_comments.append(Comment(type=status_mapping['informational'],
+                                               params={'lineno': line[1], 'code': line[2], 'message': line[3:]},
+                                               comment=f'python.pylint.{line[0]}'))
+            else:
+                pylint_comments.append(Comment(type=status_mapping[line[0]],
+                                               params={'lineno': line[1], 'code': line[2], 'message': line[3:]},
+                                               comment=f'python.pylint.{line[0]}'))
 
     return pylint_comments
-    


### PR DESCRIPTION
- [x] Added logic in `pylint_comments.py` to exempt line checks from comments.
- [x] Added logic in `pylint_comments.py` to consider docstrings, module docstrings, and trailing lines as "informational" only.
- [x] Corrected spelling in `exercise.py` & `analysis.py`
- [x] Added the same analyzer comments that are in `website-copy`, for testing purposes. 

This should be enough to use Pylint as a "base" analyzer for exercises.  Obviously, this will need to be refactored..but we're calling this done for launch.  