### PR TITLE
Added basic Pylint analyzers/checkers to Concept Exercises 

### DIFF
--- a/lib/card-games/analyzer.py
+++ b/lib/card-games/analyzer.py
@@ -1,0 +1,59 @@
+"""
+Basic analyzer for the `card-games` exercise.
+Only has pylint checks active currently.
+"""
+import ast
+from pylint import epylint as lint
+from pathlib import Path
+
+from common import Analysis, BaseFeedback, Summary
+from common.comment import Comment, CommentTypes
+from common.pylint_comments import generate_pylint_comments
+
+
+
+class Comments(BaseFeedback):
+    NO_MODULE = ("general", "no_module")
+    NO_METHOD = ("two-fer", "no_method")
+    MALFORMED_CODE = ("general", "malformed_code")
+
+def analyze(in_path: Path, out_path: Path):
+    """
+    Analyze the user's Two Fer solution to give feedback. Outputs a JSON that
+
+    conforms to https://github.com/exercism/docs/blob/main/building/tooling/analyzers/interface.md#output-format
+    """
+
+    # List of Comment objects to process
+    comments = []
+
+    output_file = out_path.parent.joinpath("analysis.json")
+
+    # input file - if it can't be found, fail and bail
+    try:
+        user_solution = in_path.read_text()
+    except OSError as err:
+        # fail out fast with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+
+    # AST - if an AST can't be made, fail and bail
+    try:
+        tree = ast.parse(user_solution)
+    except Exception:
+        # If ast.parse fails, assume malformed code and fail with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+
+    # Generate PyLint comments for additional feedback.
+    comments.extend(generate_pylint_comments(in_path))
+
+
+
+    return Analysis.summarize_comments(comments, output_file)

--- a/lib/card-games/analyzer.py
+++ b/lib/card-games/analyzer.py
@@ -10,8 +10,6 @@ from common import Analysis, BaseFeedback, Summary
 from common.comment import Comment, CommentTypes
 from common.pylint_comments import generate_pylint_comments
 
-
-
 class Comments(BaseFeedback):
     NO_MODULE = ("general", "no_module")
     NO_METHOD = ("two-fer", "no_method")
@@ -19,7 +17,7 @@ class Comments(BaseFeedback):
 
 def analyze(in_path: Path, out_path: Path):
     """
-    Analyze the user's Two Fer solution to give feedback. Outputs a JSON that
+    Analyze the user's Two Fer solution to give feedback. Outputs JSON that
 
     conforms to https://github.com/exercism/docs/blob/main/building/tooling/analyzers/interface.md#output-format
     """
@@ -39,7 +37,6 @@ def analyze(in_path: Path, out_path: Path):
         if comments:
             return Analysis.require(comments).dump(output_file)
 
-
     # AST - if an AST can't be made, fail and bail
     try:
         tree = ast.parse(user_solution)
@@ -53,7 +50,5 @@ def analyze(in_path: Path, out_path: Path):
 
     # Generate PyLint comments for additional feedback.
     comments.extend(generate_pylint_comments(in_path))
-
-
 
     return Analysis.summarize_comments(comments, output_file)

--- a/lib/card-games/analyzer.py
+++ b/lib/card-games/analyzer.py
@@ -1,6 +1,6 @@
 """
 Basic analyzer for the `card-games` exercise.
-Only has pylint checks active currently.
+Only Pylint checks are active currently.
 """
 import ast
 from pylint import epylint as lint

--- a/lib/cater-waiter/analyzer.py
+++ b/lib/cater-waiter/analyzer.py
@@ -10,8 +10,6 @@ from common import Analysis, BaseFeedback, Summary
 from common.comment import Comment, CommentTypes
 from common.pylint_comments import generate_pylint_comments
 
-
-
 class Comments(BaseFeedback):
     NO_MODULE = ("general", "no_module")
     NO_METHOD = ("two-fer", "no_method")
@@ -39,7 +37,6 @@ def analyze(in_path: Path, out_path: Path):
         if comments:
             return Analysis.require(comments).dump(output_file)
 
-
     # AST - if an AST can't be made, fail and bail
     try:
         tree = ast.parse(user_solution)
@@ -50,10 +47,7 @@ def analyze(in_path: Path, out_path: Path):
         if comments:
             return Analysis.require(comments).dump(output_file)
 
-
     # Generate PyLint comments for additional feedback.
     comments.extend(generate_pylint_comments(in_path))
-
-
 
     return Analysis.summarize_comments(comments, output_file)

--- a/lib/cater-waiter/analyzer.py
+++ b/lib/cater-waiter/analyzer.py
@@ -1,0 +1,59 @@
+"""
+Analyzer for the `cater-waiter` exercise.
+Only has Pylint check active currently.
+"""
+import ast
+from pylint import epylint as lint
+from pathlib import Path
+
+from common import Analysis, BaseFeedback, Summary
+from common.comment import Comment, CommentTypes
+from common.pylint_comments import generate_pylint_comments
+
+
+
+class Comments(BaseFeedback):
+    NO_MODULE = ("general", "no_module")
+    NO_METHOD = ("two-fer", "no_method")
+    MALFORMED_CODE = ("general", "malformed_code")
+
+def analyze(in_path: Path, out_path: Path):
+    """
+    Analyze the user's Two Fer solution to give feedback. Outputs a JSON that
+
+    conforms to https://github.com/exercism/docs/blob/main/building/tooling/analyzers/interface.md#output-format
+    """
+
+    # List of Comment objects to process
+    comments = []
+
+    output_file = out_path.parent.joinpath("analysis.json")
+
+    # input file - if it can't be found, fail and bail
+    try:
+        user_solution = in_path.read_text()
+    except OSError as err:
+        # fail out fast with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+
+    # AST - if an AST can't be made, fail and bail
+    try:
+        tree = ast.parse(user_solution)
+    except Exception:
+        # If ast.parse fails, assume malformed code and fail with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+
+    # Generate PyLint comments for additional feedback.
+    comments.extend(generate_pylint_comments(in_path))
+
+
+
+    return Analysis.summarize_comments(comments, output_file)

--- a/lib/chaitanas-colossal-coaster/analyzer.py
+++ b/lib/chaitanas-colossal-coaster/analyzer.py
@@ -1,0 +1,59 @@
+"""
+Analyzer for the `chaitanas colossal coaster` exercise.
+Currently only has pylint checks active.
+"""
+import ast
+from pylint import epylint as lint
+from pathlib import Path
+
+from common import Analysis, BaseFeedback, Summary
+from common.comment import Comment, CommentTypes
+from common.pylint_comments import generate_pylint_comments
+
+
+
+class Comments(BaseFeedback):
+    NO_MODULE = ("general", "no_module")
+    NO_METHOD = ("two-fer", "no_method")
+    MALFORMED_CODE = ("general", "malformed_code")
+
+def analyze(in_path: Path, out_path: Path):
+    """
+    Analyze the user's Two Fer solution to give feedback. Outputs a JSON that
+
+    conforms to https://github.com/exercism/docs/blob/main/building/tooling/analyzers/interface.md#output-format
+    """
+
+    # List of Comment objects to process
+    comments = []
+
+    output_file = out_path.parent.joinpath("analysis.json")
+
+    # input file - if it can't be found, fail and bail
+    try:
+        user_solution = in_path.read_text()
+    except OSError as err:
+        # fail out fast with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+
+    # AST - if an AST can't be made, fail and bail
+    try:
+        tree = ast.parse(user_solution)
+    except Exception:
+        # If ast.parse fails, assume malformed code and fail with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+
+    # Generate PyLint comments for additional feedback.
+    comments.extend(generate_pylint_comments(in_path))
+
+
+
+    return Analysis.summarize_comments(comments, output_file)

--- a/lib/chaitanas-colossal-coaster/analyzer.py
+++ b/lib/chaitanas-colossal-coaster/analyzer.py
@@ -10,8 +10,6 @@ from common import Analysis, BaseFeedback, Summary
 from common.comment import Comment, CommentTypes
 from common.pylint_comments import generate_pylint_comments
 
-
-
 class Comments(BaseFeedback):
     NO_MODULE = ("general", "no_module")
     NO_METHOD = ("two-fer", "no_method")
@@ -39,7 +37,6 @@ def analyze(in_path: Path, out_path: Path):
         if comments:
             return Analysis.require(comments).dump(output_file)
 
-
     # AST - if an AST can't be made, fail and bail
     try:
         tree = ast.parse(user_solution)
@@ -50,10 +47,7 @@ def analyze(in_path: Path, out_path: Path):
         if comments:
             return Analysis.require(comments).dump(output_file)
 
-
     # Generate PyLint comments for additional feedback.
     comments.extend(generate_pylint_comments(in_path))
-
-
 
     return Analysis.summarize_comments(comments, output_file)


### PR DESCRIPTION
Added base `analyzer.py` files for `card-games`, `cater-waiter`, and `chaitanas-colossal-coaster`.  
This will enable them to have a Pylint check as basic analysis while we get more custom analysis written.