### PR TITLE
[Ellen's Alien Game]: Add Analyzer and Custom pylintrc File

### DIFF
--- a/lib/common/.pylintrc
+++ b/lib/common/.pylintrc
@@ -2,12 +2,17 @@
 # This common pylintrc file contains a best-effort configuration to uphold the
 # best-practices and style for the Python track exercises of exercism.org.
 #
-# As a default, all warnings and checks are "turned on", although that may
-# change in the future, as we decide which rules to enforce for all exercises.
-#
 # This file is used when there is no exercise-specific pylintrc.
 # When there is an exercise-specific pylintrc, this config file is ignored
 # in favor of the exercise-specific config.
+#
+# As a default, all warnings and checks are "turned on", although that may
+# change in the future, as we decide which rules to enforce for all exercises.
+#
+# **A note on single letter variable names.**
+# See this Stack Overflow discussion:
+# https://stackoverflow.com/questions/21833872/why-does-pylint-object-to-single-character-variable-names
+# for why this is enforced.
 ###########################################################################
 
 
@@ -125,17 +130,17 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=main,_
+good-names=main,_, item, element, index
 
 # Bad variable names which should always be refused, separated by a comma
-bad-names=x,y,i,l
+bad-names=x,y,i,l,L,O,j,m,n,k
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.
 name-group=
 
 # Include a hint for the correct naming format with invalid-name
-include-naming-hint=no
+include-naming-hint=y
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
@@ -145,7 +150,7 @@ property-classes=abc.abstractproperty,cached_property.cached_property,cached_pro
 function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
 
 # Regular expression matching correct variable names
-variable-rgx=^[a-z][a-z0-9_]*$
+variable-rgx=^[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct constant names
 const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
@@ -154,7 +159,7 @@ const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
 attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
 
 # Regular expression matching correct argument names
-argument-rgx=^[a-z][a-z0-9_]*$
+argument-rgx=^[a-z][a-z0-9_]{1,30}$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$

--- a/lib/common/.pylintrc
+++ b/lib/common/.pylintrc
@@ -1,0 +1,385 @@
+###########################################################################
+# This common pylintrc file contains a best-effort configuration to uphold the
+# best-practices and style for the Python track exercises of exercism.org.
+#
+# As a default, all warnings and checks are "turned on", although that may
+# change in the future, as we decide which rules to enforce for all exercises.
+#
+# This file is used when there is no exercise-specific pylintrc.
+# When there is an exercise-specific pylintrc, this config file is ignored
+# in favor of the exercise-specific config.
+###########################################################################
+
+
+[MASTER]
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=third_party
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#  inconsistent-return-statements,
+# disable=arguments-differ,
+#        attribute-defined-outside-init,
+#        duplicate-code,
+#        filter-builtin-not-iterating,
+#        fixme,
+#        global-statement,
+#        implicit-str-concat-in-sequence,
+#        import-error,
+#        import-self,
+#        input-builtin,
+#        locally-disabled,
+#        misplaced-comparison-constant,
+#        missing-class-docstring,
+#        missing-function-docstring,
+#        missing-module-docstring,
+#        no-absolute-import,
+#        no-else-break,
+#        no-else-continue,
+#        no-else-raise,
+#        no-else-return,
+#        no-member,
+#        no-name-in-module,
+#        no-self-use,
+#        raising-string,
+#        relative-import,
+#        round-builtin,
+#        signature-differs,
+#        suppressed-message,
+#        too-few-public-methods,
+#        too-many-ancestors,
+#        too-many-arguments,
+#        too-many-boolean-expressions,
+#        too-many-branches,
+#        too-many-instance-attributes,
+#        too-many-locals,
+#        too-many-nested-blocks,
+#        too-many-public-methods,
+#        too-many-return-statements,
+#        too-many-statements,
+#        unused-argument,
+#        unused-import,
+#        useless-suppression
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+# output-format=colorized
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=x,y,i,l
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+
+# Regular expression matching correct function names
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct constant names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression matching correct module names
+module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$
+
+# Regular expression matching correct method names
+method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
+# lines made too long by directives to pytype.
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)(
+  ^\s*(\#\ )?<?https?://\S+>?$|
+  ^\s*(from\s+\S+\s+)?import\s+.+$)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=yes
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit. Currently 4, consistent with
+# PEP 8.
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=TODO
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging,absl.logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec,
+                   sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant, absl
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,
+                            class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException

--- a/lib/common/pylint_comments.py
+++ b/lib/common/pylint_comments.py
@@ -3,17 +3,17 @@ from pylint import epylint as lint
 from pathlib import Path
 
 
-def generate_pylint_comments(in_path):
-    '''
-        Use Pylint to generate additional feedback comments for code,
+def generate_pylint_comments(in_path, pylint_spec='/opt/analyzer/lib/common/.pylintrc'):
+    """Use Pylint to generate additional feedback comments for code.
 
         e.g. if code follows PEP8 Style Convention
-    '''
+    """
 
-    pylint_stdout, _ = lint.py_run(
-        str(in_path) + ' --score=no --msg-template="{category}, {line}, {msg_id} {symbol}, {msg}"',
-        return_std=True
-    )
+    template = '--msg-template="{category}, {line}, {msg_id} {symbol}, {msg}"'
+    rcfile = f'--rcfile={pylint_spec}'
+    cmnd_line_options = f" {rcfile} --score=no {template}"
+
+    pylint_stdout, _ = lint.py_run(str(in_path) + cmnd_line_options, return_std=True)
 
     status_mapping = {
         'informational': CommentTypes.INFORMATIVE,

--- a/lib/ellens-alien-game/.pylintrc
+++ b/lib/ellens-alien-game/.pylintrc
@@ -1,0 +1,376 @@
+###########################################################################
+# This pylintrc file contains a best-effort configuration to uphold the
+# best-practices and style for the Python track of exercism.org.
+#
+# It is based on the the Google pylintrc & the Google Python style guide:
+#   https://google.github.io/styleguide/pyguide.html,
+#   https://google.github.io/styleguide/pylintrc
+#
+# Additions & alterations to the Google Style guide are noted in
+# the Exercism Python Track contributing guide:
+#   https://github.com/exercism/python/blob/main/CONTRIBUTING.md
+###########################################################################
+
+
+[MASTER]
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=third_party
+
+# Files or directories matching the regex patterns are skipped. The regex
+# matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=4
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+#  inconsistent-return-statements,
+disable=arguments-differ,
+        attribute-defined-outside-init,
+        filter-builtin-not-iterating,
+        fixme,
+        global-statement,
+        implicit-str-concat-in-sequence,
+        import-error,
+        import-self,
+        input-builtin,
+        locally-disabled,
+        misplaced-comparison-constant,
+        no-absolute-import,
+        no-else-break,
+        no-else-continue,
+        no-else-raise,
+        no-else-return,
+        no-member,
+        no-name-in-module,
+        raising-string,
+        relative-import,
+        round-builtin,
+        signature-differs,
+        suppressed-message,
+        too-many-boolean-expressions,
+        too-many-branches,
+        too-many-locals,
+        too-many-public-methods,
+        too-many-return-statements,
+        too-many-statements,
+        unnecessary-pass,
+        unused-argument,
+        useless-suppression
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+# output-format=colorized
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=main,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=x,y,i,l
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty,cached_property.cached_property,cached_property.threaded_cached_property,cached_property.cached_property_with_ttl,cached_property.threaded_cached_property_with_ttl
+
+# Regular expression matching correct function names
+function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
+
+# Regular expression matching correct variable names
+variable-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct constant names
+const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct attribute names
+attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
+
+# Regular expression matching correct argument names
+argument-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=^[a-z][a-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=^_?[A-Z][a-zA-Z0-9]*$
+
+# Regular expression matching correct module names
+module-rgx=^(_?[a-z][a-z0-9_]*|__init__)$
+
+# Regular expression matching correct method names
+method-rgx=(?x)^(?:(?P<exempt>_[a-z0-9_]+__|runTest|setUp|tearDown|setUpTestCase|tearDownTestCase|setupSelf|tearDownClass|setUpClass|(test|assert)_*[A-Z0-9][a-zA-Z0-9_]*|next)|(?P<camel_case>_{0,2}[A-Z][a-zA-Z0-9_]*)|(?P<snake_case>_{0,2}[a-z][a-z0-9_]*))$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=(__.*__|main|test.*|.*test|.*Test)$
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=10
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager,contextlib2.contextmanager
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=120
+
+# TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
+# lines made too long by directives to pytype.
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=(?x)(
+  ^\s*(\#\ )?<?https?://\S+>?$|
+  ^\s*(from\s+\S+\s+)?import\s+.+$)
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=yes
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=
+
+# Maximum number of lines in a module
+max-module-lines=99999
+
+# String used as indentation unit. Currently 4, consistent with
+# PEP 8.
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=TODO
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=^\*{0,2}(_$|unused_|dummy_)
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six,six.moves,past.builtins,future.builtins,functools
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging,absl.logging
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec,
+                   sets
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant, absl
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls,
+                            class_
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=StandardError,
+                       Exception,
+                       BaseException

--- a/lib/ellens-alien-game/.pylintrc
+++ b/lib/ellens-alien-game/.pylintrc
@@ -2,6 +2,10 @@
 # This pylintrc file contains a best-effort configuration for the concept
 # exercise Ellen's Alien Game on the Python track of exercism.org.
 #
+# Regarding single letter variable names: this Stack Overflow discussion
+# https://stackoverflow.com/questions/21833872/why-does-pylint-object-to-single-character-variable-names
+# explains why this is enforced.
+#
 # **PLEASE NOTE**
 # Since this exercise covers the use of 'pass' as well as the use of class
 # attributes, we have disabled 'unnecessary-pass' and 'attribute-defined-outside-init'
@@ -112,17 +116,17 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=main,_
+good-names=main,_, item, element, index
 
 # Bad variable names which should always be refused, separated by a comma
-bad-names=x,y,i,l
+bad-names=x,y,i,l,L,O,j,m,n,k
 
 # Colon-delimited sets of names that determine each other's naming style when
 # the name regexes allow several styles.
 name-group=
 
 # Include a hint for the correct naming format with invalid-name
-include-naming-hint=no
+include-naming-hint=yes
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
@@ -132,7 +136,7 @@ property-classes=abc.abstractproperty,cached_property.cached_property,cached_pro
 function-rgx=^(?:(?P<exempt>setUp|tearDown|setUpModule|tearDownModule)|(?P<camel_case>_?[A-Z][a-zA-Z0-9]*)|(?P<snake_case>_?[a-z][a-z0-9_]*))$
 
 # Regular expression matching correct variable names
-variable-rgx=^[a-z][a-z0-9_]*$
+variable-rgx=^[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct constant names
 const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
@@ -141,7 +145,7 @@ const-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$
 attr-rgx=^_{0,2}[a-z][a-z0-9_]*$
 
 # Regular expression matching correct argument names
-argument-rgx=^[a-z][a-z0-9_]*$
+argument-rgx=^[a-z_][a-z0-9_]{1,30}$
 
 # Regular expression matching correct class attribute names
 class-attribute-rgx=^(_?[A-Z][A-Z0-9_]*|__[a-z0-9_]+__|_?[a-z][a-z0-9_]*)$

--- a/lib/ellens-alien-game/.pylintrc
+++ b/lib/ellens-alien-game/.pylintrc
@@ -1,14 +1,11 @@
 ###########################################################################
-# This pylintrc file contains a best-effort configuration to uphold the
-# best-practices and style for the Python track of exercism.org.
+# This pylintrc file contains a best-effort configuration for the concept
+# exercise Ellen's Alien Game on the Python track of exercism.org.
 #
-# It is based on the the Google pylintrc & the Google Python style guide:
-#   https://google.github.io/styleguide/pyguide.html,
-#   https://google.github.io/styleguide/pylintrc
-#
-# Additions & alterations to the Google Style guide are noted in
-# the Exercism Python Track contributing guide:
-#   https://github.com/exercism/python/blob/main/CONTRIBUTING.md
+# **PLEASE NOTE**
+# Since this exercise covers the use of 'pass' as well as the use of class
+# attributes, we have disabled 'unnecessary-pass' and 'attribute-defined-outside-init'
+# and may disable similar checks in the future.
 ###########################################################################
 
 
@@ -60,7 +57,6 @@ confidence=
 #  inconsistent-return-statements,
 disable=arguments-differ,
         attribute-defined-outside-init,
-        filter-builtin-not-iterating,
         fixme,
         global-statement,
         implicit-str-concat-in-sequence,

--- a/lib/ellens-alien-game/analyzer.py
+++ b/lib/ellens-alien-game/analyzer.py
@@ -1,0 +1,55 @@
+"""Analyzer for the `ellens-alien-game` exercise.
+
+Only has Pylint check active currently.
+"""
+
+import ast
+from pathlib import Path
+from pylint import epylint as lint
+
+from common import Analysis, BaseFeedback, Summary
+from common.comment import Comment, CommentTypes
+from common.pylint_comments import generate_pylint_comments
+
+
+class Comments(BaseFeedback):
+    NO_MODULE = ("general", "no_module")
+    NO_METHOD = ("two-fer", "no_method")
+    MALFORMED_CODE = ("general", "malformed_code")
+
+def analyze(in_path: Path, out_path: Path):
+    """Analyze the user's solution and give feedback.
+
+    Outputs a JSON that conforms to
+    https://github.com/exercism/docs/blob/main/building/tooling/analyzers/interface.md#output-format
+    """
+
+    # List of Comment objects to process
+    comments = []
+
+    output_file = out_path.parent.joinpath("analysis.json")
+
+    # input file - if it can't be found, fail and bail
+    try:
+        user_solution = in_path.read_text()
+    except OSError as err:
+        # fail out fast with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+    # AST - if an AST can't be made, fail and bail
+    try:
+        tree = ast.parse(user_solution)
+    except Exception:
+        # If ast.parse fails, assume malformed code and fail with an ESSENTIAL (required) type comment for the student
+        comments.append(Comment(type=CommentTypes.ESSENTIAL, params={}, comment=Comments.MALFORMED_CODE))
+    finally:
+        if comments:
+            return Analysis.require(comments).dump(output_file)
+
+    # Generate PyLint comments for additional feedback.
+    comments.extend(generate_pylint_comments(in_path, pylint_spec='/opt/analyzer/lib/ellens-alien-game/.pylintrc'))
+
+    return Analysis.summarize_comments(comments, output_file)

--- a/test/two-fer/two_fer_test.py
+++ b/test/two-fer/two_fer_test.py
@@ -122,8 +122,7 @@ class TwoFerTest(BaseExerciseTest, unittest.TestCase):
         """
         analysis = self.get_analysis(USES_STRING_FORMAT)
         print(analysis)
-        self.assertIs(analysis.summary, Summary.CELEBRATE)
-        self.assertFalse(analysis.comment)
+        self.assertIs(analysis.summary, Summary.DIRECT)
 
     def test_approves_optimal_f_string(self):
         """

--- a/test/two-fer/two_fer_test.py
+++ b/test/two-fer/two_fer_test.py
@@ -17,17 +17,18 @@ if str(LIBRARY) not in sys.path:
 from common import Analysis, BaseExerciseTest, BaseFeedback, Exercise, Summary
 
 
-USES_STRING_FORMAT = """
-'''
-My Answer to Exercism Python Track Two-Fer Exercise.
-'''
-def two_fer(name='you'):
-    '''This function takes a name and prints out one for [name], one for me.
+USES_STRING_FORMAT = '''
+"""Answer to Exercism Python Track Two-Fer Exercise.
+"""
 
-    In the absence of a name, it prints you.'''
+def two_fer(name="you"):
+    """Take a name and print out one for [name], one for me.
+
+    In the absence of a name, it print you."""
+    
     return "One for {}, one for me.".format(name)
     
-"""
+'''
 
 USES_F_STRING = """
 '''


### PR DESCRIPTION
Added base analyzer for `Ellen's Alien Game` (`classes`).

-  [x] Due to CI failures, edited test file for `two-fer` (_it did not take pylint comments into account_)
-  [x] Added `lib/ellens-alien-game/analyzer.py`
-  [x] Added `lib/ellens-alien-game/.pylintrc`
-  [x] Altered `lib/common/pylint_comments.py` to accept exercise specific config files, with a default in `lib/common/`
-  [x] Added default `.pylintrc` configuration in `lib/common`

With the last two changes, we're ~~moving~~ inching toward exercise-specific pylint configurations, in preparation for creating new pylint-style rules to better analyze solutions.