### PR TITLE
Update to Python 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 RUN apt-get update \
- && apt-get install curl -y \
- && apt-get remove curl -y \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR updates the analyzer to Python 3.10. Also installing curl just to remove it seems unnecessary.

## Related PRs

- https://github.com/exercism/python-representer/pull/34
- https://github.com/exercism/python-analyzer/pull/54