### PR TITLE
[Analyzer Upgrades]: First Pass at Upgrading to python:3.10.6-slim.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10.6-slim
 
 RUN apt-get update \
  && apt-get install curl -y \

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,3 @@
-pytest>=5.3.1,!=5.4.0
+pytest~=7.1.2
+pytest-subtests~=0.5.0
+tomli~=2.0.1

--- a/lib/common/.pylintrc
+++ b/lib/common/.pylintrc
@@ -234,7 +234,8 @@ single-line-if-stmt=yes
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
 # `trailing-comma` allows a space between comma and closing bracket: (a, ).
 # `empty-line` allows space-only lines.
-no-space-check=
+# As of Pylint 2.6+, this option has been disabled, so this is commented out.
+# no-space-check=
 
 # Maximum number of lines in a module
 max-module-lines=99999

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pylint
+pylint~=2.14.5


### PR DESCRIPTION
**Please Note:** This PR **should not be merged** without also merging the related PRs in the `python-test-runner`, `python-representer`, and `python` repos:

- [`python main repo` #3158](https://github.com/exercism/python/pull/3158)
- [`python-test-runner` #105](https://github.com/exercism/python-test-runner/pull/105)
- [`python-representer` #35](https://github.com/exercism/python-representer/pull/35)

<br>

- [x] Changed Dockerfile to use `python:3.10.6-slim`
- [x] Updated & pinned version for `pylint` in `requirements.txt`
- [x] Updated & pinned versions for `pytest` and `tomli` in `dev-requirements.txt`
- [x] Ran tests for the analyzer
- [x] Spot checked analysis for some exercises