### PR TITLE
[Python 3.11.2 Upgrade] Updated Dockerfile & Requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.6-slim
+FROM python:3.11.2-slim
 
 RUN apt-get update \
  && apt-get install curl -y \
@@ -12,3 +12,4 @@ WORKDIR /opt/analyzer
 
 RUN pip install -r requirements.txt -r dev-requirements.txt
 ENTRYPOINT ["/opt/analyzer/bin/run.sh"]
+

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ For example:
 Unit tests can be run from this directory:
 
 ```bash
-pylint -x
+pytest -x
 ```

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-pytest~=7.1.2
-pytest-subtests~=0.5.0
-tomli~=2.0.1
+pytest~=7.2.2
+pytest-subtests~=0.10.0
+tomli>=1.1.0; python_full_version < '3.11.2'

--- a/lib/common/.pylintrc
+++ b/lib/common/.pylintrc
@@ -104,6 +104,8 @@ confidence=
 #        unused-argument,
 #        unused-import,
 #        useless-suppression
+disable=trailing-whitespace,missing-final-newline
+
 
 [REPORTS]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-pylint~=2.14.5
+pylint >=2.17.1
+plerr ~=3.0.0


### PR DESCRIPTION
**`This upgrade should happen at the same time for the`  [Test Runner](https://github.com/exercism/python-test-runner), [Analyzer](https://github.com/exercism/python-analyzer/pull/63), & [Representer](https://github.com/exercism/python-representer/pull/41)**
 After these three are merged, the updates to the [track CI](https://github.com/exercism/python/pull/3382) and [Content](https://github.com/exercism/python/pull/3384) should be merged.

- Updated Dockerfile to use `python:3.11.2-slim`
- Updated dev-requirements.txt
   -  pytest~=7.2.2 🎉 
   -  pytest-subtests~=0.10.0
- Updated requirements.txt
   - pylint >=2.17.1
- Changed common `.pylintrc` file
    -  disable=trailing-whitespace,missing-final-newline 
       (_given that you can't see these/easily fix them in the online editor, they were really irritating to students_)
- Fixed the incorrect instructions on the README.  Tests need to be run using `pytest`, not `pylint`

________

Golden files need to be made, but will follow in a post-upgrade PR.
Turning on analysis for practice exercises will also follow in a post-upgrade PR.