### PR TITLE
[Pin PyLint Version]: Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pylint >=2.17.1
+pylint ==2.17.7
 plerr ~=3.0.0


### PR DESCRIPTION
Pinned to version `2.17.7`, until we can update the code to not depend on `epylint`.  We also need to update/depreciate Python `3.7`, since versions of Pylint higher than 2.17.7 no longer support it.