### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     name: Test Analyzer
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
 
       - name: Build Docker Image
         run: docker build -f Dockerfile -t python-analyzer .


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.