### PR TITLE
[PyLint Feedback Message Details]: Corrected Munged Links in `details.md` Files

### DIFF
--- a/lib/common/pylint_data/messages/bad-str-strip-call/details.md
+++ b/lib/common/pylint_data/messages/bad-str-strip-call/details.md
@@ -1,11 +1,11 @@
-A common misconception is that [str.strip(\'Hello\')]{.title-ref}
-removes the *substring* [\'Hello\']{.title-ref} from the beginning and
-end of the string. This is **not** the case. From the
-\[documentation\](<https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip>):
+A common misconception is that [str.strip('Hello')](https://docs.python.org/3.13/library/stdtypes.html#str.strip)
+removes the *substring* `'Hello'` from the beginning and
+end of the larger lstring. This is **not** the case. From the
+[Python documentation](<https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip>):
 
-\> The chars argument is not a prefix or suffix; rather, all
-combinations of its values are stripped.
+> The chars argument is not a prefix or suffix; rather, **all
+combinations of its values are stripped.**_
 
-Duplicated characters in the [str.strip]{.title-ref} call, besides not
+Duplicated characters in the [str.strip()](https://docs.python.org/3.13/library/stdtypes.html#str.strip) call, besides not
 having any effect on the actual result, may indicate this
 misunderstanding, and lead to future bugs.

--- a/lib/common/pylint_data/messages/bad-str-strip-call/details.md
+++ b/lib/common/pylint_data/messages/bad-str-strip-call/details.md
@@ -3,7 +3,7 @@ removes the *substring* `'Hello'` from the beginning and
 end of the larger lstring. This is **not** the case. From the
 [Python documentation](<https://docs.python.org/3/library/stdtypes.html?highlight=strip#str.strip>):
 
-> The chars argument is not a prefix or suffix; rather, **all
+> _The chars argument is not a prefix or suffix; rather, **all
 combinations of its values are stripped.**_
 
 Duplicated characters in the [str.strip()](https://docs.python.org/3.13/library/stdtypes.html#str.strip) call, besides not

--- a/lib/common/pylint_data/messages/bad-super-call/details.md
+++ b/lib/common/pylint_data/messages/bad-super-call/details.md
@@ -1,11 +1,11 @@
-In Python 2.7, [super()]{.title-ref} has to be called with its own class
-and [self]{.title-ref} as arguments ([super(Cat, self)]{.title-ref}),
-which can lead to a mix up of parent and child class in the code.
+In Python 2.7, [super()](https://docs.python.org/2.7/library/functions.html#super) has to be called with its own class
+and `self` as arguments ([super(Cat, self)](https://docs.python.org/2.7/library/functions.html#super)),
+which can lead to a mix-up of parent and child class in the code.
 
-In Python 3 the recommended way is to call [super()]{.title-ref}
-[without]{#without} [arguments]() (see also
-[super-with-arguments]{.title-ref}).
+In Python 3 the recommended way is to call [super()](https://docs.python.org/3/library/functions.html#super) _without_
+[arguments](https://docs.python.org/3/glossary.html#term-argument) (see also
+[super-considered-super](https://rhettinger.wordpress.com/2011/05/26/super-considered-super/)).
 
-One exception is calling [super()]{.title-ref} on a non-direct parent
+One exception is calling `super()` on a non-direct parent
 class. This can be used to get a method other than the default method
-returned by the [mro()]{.title-ref}.
+returned by the [mro()](https://docs.python.org/3/glossary.html#term-method-resolution-order).

--- a/lib/common/pylint_data/messages/invalid-all-object/details.md
+++ b/lib/common/pylint_data/messages/invalid-all-object/details.md
@@ -1,6 +1,3 @@
 From [The Python Language Reference -- The import statement](https://docs.python.org/3/reference/simple_stmts.html#the-import-statement):
 
-:   \"The [public names]{.title-ref} defined by a module are determined
-    by checking the module\'s namespace for a variable named `__all__`;
-    if defined, it must be a sequence of strings which are names defined
-    or imported by that module.\"
+> The _public names_ defined by a module are determined by checking the module’s namespace for a variable named `__all__`; if defined, it must be a sequence of strings which are names defined or imported by that module.

--- a/lib/common/pylint_data/messages/possibly-used-before-assignment/details.md
+++ b/lib/common/pylint_data/messages/possibly-used-before-assignment/details.md
@@ -17,14 +17,13 @@ if suffix in "dmy":
     handle_date_suffix(suffix)
 ```
 
-Or, instead of [assert_never()]{.title-ref}, you can call a function
-with a return annotation of [Never]{.title-ref} or
-[NoReturn]{.title-ref}. Unlike in the general case, where by design
+Or, instead of [`assert_never()`](https://typing.python.org/en/latest/guides/unreachable.html#assert-never-and-exhaustiveness-checking), you can call a function
+with a return annotation of [`Never` or `NoReturn`](https://typing.python.org/en/latest/guides/unreachable.html#never-and-noreturn). Unlike in the general case, where (by design)
 pylint ignores type annotations and does its own static analysis, here,
 pylint treats these special annotations like a disable comment.
 
-Pylint currently allows repeating the same test like this, even though
-this lets some error cases through, as pylint does not assess the
+Pylint currently allows repeating the same test in this way, even though
+it lets some error cases through, as pylint does not assess the
 intervening code:
 
 ``` python

--- a/lib/common/pylint_data/messages/redefined-outer-name/details.md
+++ b/lib/common/pylint_data/messages/redefined-outer-name/details.md
@@ -1,5 +1,5 @@
 A common issue is that this message is triggered when using
-[pytest]{.title-ref}
+[pytest](https://docs.pytest.org/en/stable/)
 [fixtures](https://docs.pytest.org/en/7.1.x/how-to/fixtures.html):
 
 ``` python
@@ -22,5 +22,5 @@ def setup_fixture():
     ...
 ```
 
-Alternatively [pylint]{.title-ref} plugins like
+Alternatively [pylint](https://www.pylint.org/) plugins like
 [pylint-pytest](https://pypi.org/project/pylint-pytest/) can be used.

--- a/lib/common/pylint_data/messages/subclassed-final-class/details.md
+++ b/lib/common/pylint_data/messages/subclassed-final-class/details.md
@@ -1,5 +1,5 @@
 This message is emitted when a class which is decorated with
-[final]{.title-ref} is subclassed; the decorator indicates that the
+[final](https://docs.python.org/3/library/typing.html#typing.final) is subclassed; the decorator indicates that the
 class is not intended to be extended.
 
 Note this message can\'t be emitted when using Python \< 3.8.

--- a/lib/common/pylint_data/messages/using-assignment-expression-in-unsupported-version/details.md
+++ b/lib/common/pylint_data/messages/using-assignment-expression-in-unsupported-version/details.md
@@ -1,3 +1,3 @@
-The assignment expression (walrus) operator ([:=]{.title-ref}) was
+The assignment expression (walrus) operator ([:=](https://docs.python.org/3/reference/expressions.html#assignment-expressions)) was
 introduced in Python 3.8; to use it, please use a more recent version of
 Python.


### PR DESCRIPTION
Per [forum post](https://forum.exercism.org/t/unparsed-markdown-in-python-analyzer-feedback-for-w0621/48709), searched for munged reStructuredText links and corrected them to markdown-style links for the `details.md` files.