### PR TITLE
[Disallowed Names Rule]: Added links in invalid-name details

### DIFF
--- a/lib/common/.pylintrc
+++ b/lib/common/.pylintrc
@@ -59,8 +59,7 @@ bad-names=x,
           b,
           j,
           o,
-          z,
-          _
+          z
 
 # Good variable names which should always be accepted, separated by a comma.
 good-names=main,

--- a/lib/common/.pylintrc
+++ b/lib/common/.pylintrc
@@ -48,7 +48,7 @@ method-naming-style=snake_case
 inlinevar-naming-style=snake_case
 
 # Include a hint for the correct naming format with invalid-name.
-include-naming-hint=yes
+include-naming-hint=no
 
 # Bad variable names which should always be refused, separated by a comma.
 bad-names=x,
@@ -59,7 +59,8 @@ bad-names=x,
           b,
           j,
           o,
-          z
+          z,
+          _
 
 # Good variable names which should always be accepted, separated by a comma.
 good-names=main,

--- a/lib/common/pylint_comments.py
+++ b/lib/common/pylint_comments.py
@@ -64,6 +64,7 @@ def generate_pylint_comments(in_path, pylint_spec='/opt/analyzer/lib/common/.pyl
                 continue
 
             if line[2] in {"C0114 missing-module-docstring",
+                           "C0115 missing-class-docstring",
                            "C0116 missing-function-docstring",
                            "C0304 missing-final-newline"}:
 
@@ -71,14 +72,18 @@ def generate_pylint_comments(in_path, pylint_spec='/opt/analyzer/lib/common/.pyl
             else:
                 status_type = status_mapping[line[0]]
 
-            pylint_comments.append(Comment(type=status_type,
-                                           params={'lineno': line[1],
-                                                   'code': line[2],
-                                                   'message': ', '.join(line[3:]),
-                                                   'bad_code': f'Instead of: \n```python\n{bad}```\n\n' if bad else None,
-                                                   'good_code': f'Try: \n```python\n{good}```\n\n' if good else None,
-                                                   'related_info': related,
-                                                   'details': details},
-                                           comment=f'python.pylint.{line[0]}'))
+            new_comment =  Comment(type=status_type,
+                                   params={'lineno': line[1],
+                                           'code': line[2],
+                                           'message': ', '.join(line[3:]),
+                                           'bad_code': f'Instead of: \n```python\n{bad}```\n\n' if bad else None,
+                                           'good_code': f'Try: \n```python\n{good}```\n\n' if good else None,
+                                           'related_info': related,
+                                           'details': details},
+                                   comment=f'python.pylint.{line[0]}')
+
+
+            if new_comment not in pylint_comments:
+                pylint_comments.append(new_comment)
 
     return pylint_comments

--- a/lib/common/pylint_data/messages/invalid-name/details.md
+++ b/lib/common/pylint_data/messages/invalid-name/details.md
@@ -1,4 +1,6 @@
 By default, Pylint enforces
 [PEP8](https://peps.python.org/pep-0008)-suggested names.
-
-For more details on the pitfalls of `_` specifically, see this Stack Overflow [answer](https://stackoverflow.com/a/5893946) and [Underscores in Python](https://shahriar.svbtle.com/underscores-in-python) by Shahriar Tajbakhsh.
+For more details on the pitfalls of `_` specifically,
+ see this Stack Overflow [answer](https://stackoverflow.com/a/5893946)
+ and [Underscores in Python](https://shahriar.svbtle.com/underscores-in-python)
+ by Shahriar Tajbakhsh.

--- a/lib/common/pylint_data/messages/invalid-name/details.md
+++ b/lib/common/pylint_data/messages/invalid-name/details.md
@@ -1,16 +1,4 @@
-By default, Pylint will enforce
+By default, Pylint enforces
 [PEP8](https://peps.python.org/pep-0008)-suggested names.
 
-The following naming suggestions are used for Exercism exercises:
-
-- modules (code files): snake_case
-- constants: UPPER_CASE
-- variables: snake_case (minimum of 3 letters)
-- functions: snake_case
-- arguments: snake_case
-- attributes: snake_case
-- classes: PascalCase
-- class attributes: any (no specific format)
-- class constants: UPPER_CASE
-- class methods: snake_case
-- inline variables and loop variables: snake_case
+For more details on the pitfalls of `_` specifically, see this Stack Overflow [answer](https://stackoverflow.com/a/5893946) and [Underscores in Python](https://shahriar.svbtle.com/underscores-in-python) by Shahriar Tajbakhsh.

--- a/test/dnd-character/analysis.json
+++ b/test/dnd-character/analysis.json
@@ -25,7 +25,7 @@
                 "related_info": null,
                 "details": null
             },
-            "type": "actionable"
+            "type": "informative"
         },
         {
             "comment": "python.pylint.refactor",
@@ -37,19 +37,6 @@
                 "good_code": "Try: \n```python\nNUMBERS = [1, 1, 2, 2, 3, 3]\n\nUNIQUE_NUMBERS = set(NUMBERS)\n```\n\n",
                 "related_info": null,
                 "details": null
-            },
-            "type": "actionable"
-        },
-        {
-            "comment": "python.pylint.refactor",
-            "params": {
-                "lineno": "19",
-                "code": "R6301 no-self-use",
-                "message": "Method could be a function",
-                "bad_code": "Instead of: \n```python\nclass Person:\n    def greeting(self):  # [no-self-use]\n        print(\"Greetings pythonista!\")\n```\n\n",
-                "good_code": "Try: \n```python\n# Function\ndef greeting():\n    print(\"Greetings pythonista!\")\n\n\n# Static Method\nclass Person:\n    @staticmethod\n    def greeting():\n        print(\"Greetings pythonista!\")\n\n# Use Self\nclass Person:\n    name: str = \"Amelia\"\n\n    def greeting(self):\n        print(f\"Greetings {self.name} the pythonista!\")\n```\n\n",
-                "related_info": null,
-                "details": "If a function is not using any class attribute it can be a\n`@staticmethod`, or a function outside the class.\n"
             },
             "type": "actionable"
         },

--- a/test/electric-bill/analysis.json
+++ b/test/electric-bill/analysis.json
@@ -10,7 +10,7 @@
                 "bad_code": "Instead of: \n```python\nclass cat:  # [invalid-name]\n    def Meow(self, NUMBER_OF_MEOW):  # [invalid-name, invalid-name]\n        print(\"Meow\" * NUMBER_OF_MEOW)\n        return NUMBER_OF_MEOW\n\n\nCat = cat().Meow(42)  # [invalid-name]\n```\n\n",
                 "good_code": "Try: \n```python\nclass Cat:\n    def meow(self, number_of_meow):\n        print(\"Meow\" * number_of_meow)\n        return number_of_meow\n\n\nCAT = Cat().meow(42)\n```\n\n",
                 "related_info": null,
-                "details": "By default, Pylint will enforce\n[PEP8](https://peps.python.org/pep-0008)-suggested names.\n\nThe following naming suggestions are used for Exercism exercises:\n\n- modules (code files): snake_case\n- constants: UPPER_CASE\n- variables: snake_case (minimum of 3 letters)\n- functions: snake_case\n- arguments: snake_case\n- attributes: snake_case\n- classes: PascalCase\n- class attributes: any (no specific format)\n- class constants: UPPER_CASE\n- class methods: snake_case\n- inline variables and loop variables: snake_case\n"
+                "details": "By default, Pylint enforces\n[PEP8](https://peps.python.org/pep-0008)-suggested names.\nFor more details on the pitfalls of `_` specifically,\n see this Stack Overflow [answer](https://stackoverflow.com/a/5893946)\n and [Underscores in Python](https://shahriar.svbtle.com/underscores-in-python)\n by Shahriar Tajbakhsh.\n"
             },
             "type": "actionable"
         }

--- a/test/guidos-gorgeous-lasagna/analysis.json
+++ b/test/guidos-gorgeous-lasagna/analysis.json
@@ -10,7 +10,7 @@
                 "bad_code": "Instead of: \n```python\nclass cat:  # [invalid-name]\n    def Meow(self, NUMBER_OF_MEOW):  # [invalid-name, invalid-name]\n        print(\"Meow\" * NUMBER_OF_MEOW)\n        return NUMBER_OF_MEOW\n\n\nCat = cat().Meow(42)  # [invalid-name]\n```\n\n",
                 "good_code": "Try: \n```python\nclass Cat:\n    def meow(self, number_of_meow):\n        print(\"Meow\" * number_of_meow)\n        return number_of_meow\n\n\nCAT = Cat().meow(42)\n```\n\n",
                 "related_info": null,
-                "details": "By default, Pylint will enforce\n[PEP8](https://peps.python.org/pep-0008)-suggested names.\n\nThe following naming suggestions are used for Exercism exercises:\n\n- modules (code files): snake_case\n- constants: UPPER_CASE\n- variables: snake_case (minimum of 3 letters)\n- functions: snake_case\n- arguments: snake_case\n- attributes: snake_case\n- classes: PascalCase\n- class attributes: any (no specific format)\n- class constants: UPPER_CASE\n- class methods: snake_case\n- inline variables and loop variables: snake_case\n"
+                "details": "By default, Pylint enforces\n[PEP8](https://peps.python.org/pep-0008)-suggested names.\nFor more details on the pitfalls of `_` specifically,\n see this Stack Overflow [answer](https://stackoverflow.com/a/5893946)\n and [Underscores in Python](https://shahriar.svbtle.com/underscores-in-python)\n by Shahriar Tajbakhsh.\n"
             },
             "type": "actionable"
         }


### PR DESCRIPTION
Also added `_` to explicitly  disallowed names.  Unable to properly quote the `_` in the Pylint message, as the truncation appears to be coming from PyLint ahead of anything the analyzer does to process it.

Also added a de-dupe step in `pylint_comments.py`, to see if that helps with instances where the same comment shows up multiple times.